### PR TITLE
use `IN_RANGE` filter to bypass arangodb bug in #178

### DIFF
--- a/tests/full/test_02_vulnerabilities.py
+++ b/tests/full/test_02_vulnerabilities.py
@@ -276,9 +276,6 @@ def minmax_test(client, param_name, param_min, param_max):
 
     url = f"/api/v1/cve/objects/"
     resp = client.get(url, query_params=filters)
-    if param_max and param_min and param_min > param_max:
-        assert resp.status_code == 400, "bad parameters"
-        return
     assert resp.status_code == 200
     resp_data = resp.json()
     for d in resp_data["objects"]:
@@ -294,13 +291,12 @@ def minmax_test(client, param_name, param_min, param_max):
 
 
 def test_extra_created_filters(client, subtests):
-    for dmin, dmax in more_created_filters(client, "created", 20):
+    for dmin, dmax in more_created_filters(client, "created", 50) + more_created_filters(client, "modified", 50):
         with subtests.test(
             "randomly_generated created_* query", created_min=dmin, created_max=dmax
         ):
             minmax_test(client, "created", dmin, dmax)
 
-    for dmin, dmax in more_created_filters(client, "modified", 20):
         with subtests.test(
             "randomly_generated modified_* query", modified_min=dmin, modified_max=dmax
         ):

--- a/vulmatch/server/arango_helpers.py
+++ b/vulmatch/server/arango_helpers.py
@@ -317,21 +317,15 @@ RETURN KEEP(doc, KEYS(doc, TRUE))
             binds["stix_ids"] = value
             filters.append("FILTER doc.id in @stix_ids")
 
-        for v in ["created", "modified"]:
-            key_min, key_max = f"{v}_min", f"{v}_max"
-            vmax = vmin = 0
+        created_min, created_max = self.query.get('created_min', ''), self.query.get('created_max', '')
+        if created_min or created_max:
+            filters.append('FILTER IN_RANGE(doc.created, @created[0], @created[1], true, true)')
+            binds['created'] = created_min, created_max
 
-            if vmin := self.query.get(key_min):
-                binds[key_min] = vmin
-                filters.append(f"FILTER doc.{v} >= @{key_min}")
-
-            if vmax := self.query.get(key_max):
-                binds[key_max] = vmax
-                filters.append(f"FILTER doc.{v} <= @{key_max}")
-
-
-            if vmin and vmax and vmax < vmin:
-                raise ValidationError(f"{key_min} must not be greater than {key_max}")
+        modified_min, modified_max = self.query.get('modified_min', ''), self.query.get('modified_max', '')
+        if modified_min or modified_max:
+            filters.append('FILTER IN_RANGE(doc.modified, @modified[0], @modified[1], true, true)')
+            binds['modified'] = modified_min, modified_max
 
         ######################## cpes_in_pattern and cpes_vulnerable filters ##############################
         union = None


### PR DESCRIPTION
closes #178

- I decided to use `IN_RANGE` because it makes use of the index, so I'm hoping it's as fast as `<=` and `>=`
- may or may not cause slow down (may also cause speed up)
- all tests should pass