### PR TITLE
Add CNA endpoints

### DIFF
--- a/vulmatch/server/arango_helpers.py
+++ b/vulmatch/server/arango_helpers.py
@@ -1097,3 +1097,24 @@ RETURN KEEP(d, KEYS(d, TRUE))
         }
 
         return Response(nav_retval)
+
+
+    def list_cnas(self):
+        name_filter = ""
+        bind_vars = {
+            "@collection": "nvd_cve_vertex_collection",
+        }
+        if name := self.query.get("name"):
+            bind_vars["name"] = self.like_string(name).lower()
+            name_filter = "FILTER doc.name LIKE @name OR doc.external_references[? ANY FILTER CURRENT.external_id LIKE @name]"
+        query = """
+        FOR doc IN @@collection //OPTIONS {indexHint: "cpe_search_inv", forceIndexHint: true}
+        FILTER doc.type == 'identity' 
+        FILTER doc._is_latest == TRUE AND doc.external_references != NULL
+        // name_filter
+        LIMIT @offset, @count
+        RETURN KEEP(doc, KEYS(doc, true))
+        """.replace(
+            "// name_filter", name_filter
+        )
+        return self.execute_query(query, bind_vars=bind_vars)

--- a/vulmatch/urls.py
+++ b/vulmatch/urls.py
@@ -40,6 +40,7 @@ router.register("arango-cve-processor", views.ACPView, "acp-view")
 # nvd
 router.register("cve", views.CveView, "cve-view")
 router.register("cpe", views.CpeView, "cpe-view")
+router.register("cna", views.CNAView, "cna-view")
 router.register("cpe/vendors", views.VendorView, "vendor-view")
 router.register("cpe/products", views.ProductView, "product-view")
 router.register("cpe/matchcriteria", views.CpeMatchView, "cpematch-view")


### PR DESCRIPTION
closes #254

## NOTE
I've decided to make `name` filter looks in name, contact_information and external_references (sourceIdentifier). 

searching `secur` for example would return` huntr.dev` whose `contact_information` is `security@huntr.dev`